### PR TITLE
Some fixes.

### DIFF
--- a/src/goclient/test.go
+++ b/src/goclient/test.go
@@ -134,23 +134,23 @@ func GetMessages() ([]bank.SendMsg) {
             Inputs: []bank.Input{
                 {
                     Address:  crypto.Address([]byte("input")),
-                    Coins:    sdk.Coins{{"atom", 10},{"bitcoint", 20}},
+                    Coins:    sdk.Coins{{"atom", 10},{"bitcoin", 20}},
                     //Sequence: 1,
                 },
                 {
                     Address:  crypto.Address([]byte("anotherinput")),
-                    Coins:    sdk.Coins{{"atom", 50},{"bitcoint", 60},{"ethereum", 70}},
+                    Coins:    sdk.Coins{{"atom", 50},{"bitcoin", 60},{"ethereum", 70}},
                     //Sequence: 1,
                 },
             },
             Outputs: []bank.Output{
                 {
                     Address: crypto.Address([]byte("output")),
-                    Coins:    sdk.Coins{{"atom", 10},{"bitcoint", 20}},
+                    Coins:    sdk.Coins{{"atom", 10},{"bitcoin", 20}},
                 },
                 {
                     Address: crypto.Address([]byte("anotheroutput")),
-                    Coins:    sdk.Coins{{"atom", 50},{"bitcoint", 60},{"ethereum", 70}},
+                    Coins:    sdk.Coins{{"atom", 50},{"bitcoin", 60},{"ethereum", 70}},
                 },
             },
         },
@@ -167,7 +167,7 @@ func main() {
 	} else {
 		fmt.Printf("Ledger Found\n")
 
-		transactionData := messages[0].GetSignBytes()
+		transactionData := messages[2].GetSignBytes()
 
 		fmt.Printf("Waiting for signature..\n")
 		signedMsg, err := ledger.Sign(transactionData)

--- a/src/ledger/src/app_main.c
+++ b/src/ledger/src/app_main.c
@@ -192,7 +192,7 @@ void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx)
                         *flags |= IO_ASYNCH_REPLY;
                     }
                     else {
-                        THROW(APDU_CODE_EXECUTION_ERROR);
+                        THROW(APDU_CODE_OK);
                     }
                     break;
 
@@ -235,7 +235,7 @@ void sign_transaction()
     int valid = signature_create_SECP256K1(transaction_get_buffer(), transaction_get_buffer_length());
 
     // FIXME: signature validation fails
-    valid = 1;
+    //valid = 1;
 
     if (valid) {
         uint8_t *signature = signature_get();


### PR DESCRIPTION
Renamed samples.go to test.go
Fixed sending long (multi-chunk) messages
Set default message to be sent from test.go to be #2