### PR TITLE
Extract correct public key for ed25519

### DIFF
--- a/src/goclient/goclient.go
+++ b/src/goclient/goclient.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/zondax/ledger-goclient"
 	"github.com/tendermint/ed25519"
+	"encoding/hex"
 )
 
 func PrintSampleFunc(message bank.SendMsg, output string) {
@@ -185,7 +186,14 @@ func testTendermintED25519(messages []bank.SendMsg, ledger *ledger_goclient.Ledg
 		fmt.Printf("\nMessage %d - Please Sign..\n", i)
 		message := messages[i].GetSignBytes()
 
+		fmt.Printf("Private key=%s\n", hex.EncodeToString(privateKey[:32]))
 		pubKey := ed25519.MakePublicKey(&privateKey)
+		fmt.Printf("Public key=%s\n", hex.EncodeToString(privateKey[32:]))
+		fmt.Printf("Public key=%s\n", hex.EncodeToString(pubKey[:]))
+
+		// Print ledger test public key for comparison only
+		pubKeyEd, _ := ledger.TestGetPublicKeyED25519()
+		fmt.Printf("ED Public key=%s\n", hex.EncodeToString(pubKeyEd))
 
 		signature := ed25519.Sign(&privateKey, message)
 		verified := ed25519.Verify(pubKey, message, signature)
@@ -337,13 +345,13 @@ func main() {
 		ledger.Logging = true
 
 		// WORKING: Sign standard signature message using ledger (SECP256K1)
-		testSECP256K1_StdSignMsg(GetStdSignMessages(), ledger)
+		//testSECP256K1_StdSignMsg(GetStdSignMessages(), ledger)
 
 		// WORKING: Sign transaction message using ledger (SECP256K1)
 		//testSECP256K1(GetMessages(), ledger)
 
 		// WORKING: Sign transaction message using tendermint sdk (ED25519)
-		//testTendermintED25519(GetMessages(), ledger)
+		testTendermintED25519(GetMessages(), ledger)
 
 		// FIXME, sign transaction message using ledger (ED25519)
 		//testED25519(GetMessages(), ledger)

--- a/src/goclient/goclient_test.go
+++ b/src/goclient/goclient_test.go
@@ -166,7 +166,7 @@ func Test_FakePublicKeyED25519(t *testing.T) {
 		len(pubKey),
 		"Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
 
-	expectedPubKey, err := hex.DecodeString("0421ee8989ab1141b07ed7b92f6eca9c5b722fd04aa1f8268242231d6f3bf4dd")
+	expectedPubKey, err := hex.DecodeString("6310a04a64842d764dcd1d0af325db65f67e95ad0fb30abd270a0ca0c40b2582")
 	require.Nil(t, err)
 
 	assert.Equal(t, expectedPubKey, pubKey)

--- a/src/ledger/src/app_main.c
+++ b/src/ledger/src/app_main.c
@@ -171,6 +171,16 @@ bool extractBip32(uint8_t* depth, uint32_t path[10], uint32_t rx, uint32_t offse
     return 1;
 }
 
+void extractPubKey(unsigned char* outputBuffer, cx_ecfp_public_key_t* pubKey)
+{
+    for (int i = 0; i < 32; i++) {
+        outputBuffer[i] = publicKey->W[64 - i];
+    }
+    if ((publicKey->W[32] & 1) != 0) {
+        outputBuffer[31] |= 0x80;
+    }
+}
+
 void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
 {
     uint16_t sw = 0;
@@ -238,17 +248,10 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                 keys_ed25519(&publicKey, &privateKey, privateKeyData);
                 memset(privateKeyData, 0, 32);
 
-                // copy public key little endian to big endian
                 unsigned char output[32];
-                for (int i = 0; i < 32; i++) {
-                    output[i] = publicKey.W[64 - i];
-                }
-                if ((publicKey.W[32] & 1) != 0) {
-                    output[31] |= 0x80;
-                }
-
-                os_memmove(G_io_apdu_buffer, output, 32);
-                *tx += 32;
+                extractPubKey(output, publicKey);
+                os_memmove(G_io_apdu_buffer, output, sizeof(output));
+                *tx += sizeof(output);
 
                 THROW(APDU_CODE_OK);
             }
@@ -373,17 +376,10 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                     cx_ecfp_private_key_t privateKey;
                     keys_ed25519(&publicKey, &privateKey, privateKeyDataTest);
 
-                    // copy public key little endian to big endian
                     unsigned char output[32];
-                    for (int i = 0; i < 32; i++) {
-                        output[i] = publicKey.W[64 - i];
-                    }
-                    if ((publicKey.W[32] & 1) != 0) {
-                        output[31] |= 0x80;
-                    }
-
-                    os_memmove(G_io_apdu_buffer, output, 32);
-                    *tx += 32;
+                    extractPubKey(output, publicKey);
+                    os_memmove(G_io_apdu_buffer, output, sizeof(output));
+                    *tx += sizeof(output);
 
                     THROW(APDU_CODE_OK);
                 }

--- a/src/ledger/src/app_main.c
+++ b/src/ledger/src/app_main.c
@@ -238,7 +238,16 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                 keys_ed25519(&publicKey, &privateKey, privateKeyData);
                 memset(privateKeyData, 0, 32);
 
-                os_memmove(G_io_apdu_buffer, publicKey.W, 32);
+                // copy public key little endian to big endian
+                unsigned char output[32];
+                for (int i = 0; i < 32; i++) {
+                    output[i] = publicKey.W[64 - i];
+                }
+                if ((publicKey.W[32] & 1) != 0) {
+                    output[31] |= 0x80;
+                }
+
+                os_memmove(G_io_apdu_buffer, output, 32);
                 *tx += 32;
 
                 THROW(APDU_CODE_OK);
@@ -362,9 +371,18 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                     // Generate key
                     cx_ecfp_public_key_t publicKey;
                     cx_ecfp_private_key_t privateKey;
-                    keys_ed25519(&publicKey, &privateKey, privateKeyDataTest );
+                    keys_ed25519(&publicKey, &privateKey, privateKeyDataTest);
 
-                    os_memmove(G_io_apdu_buffer, publicKey.W, 32);
+                    // copy public key little endian to big endian
+                    unsigned char output[32];
+                    for (int i = 0; i < 32; i++) {
+                        output[i] = publicKey.W[64 - i];
+                    }
+                    if ((publicKey.W[32] & 1) != 0) {
+                        output[31] |= 0x80;
+                    }
+
+                    os_memmove(G_io_apdu_buffer, output, 32);
                     *tx += 32;
 
                     THROW(APDU_CODE_OK);

--- a/src/ledger/src/app_main.c
+++ b/src/ledger/src/app_main.c
@@ -174,9 +174,9 @@ bool extractBip32(uint8_t* depth, uint32_t path[10], uint32_t rx, uint32_t offse
 void extractPubKey(unsigned char* outputBuffer, cx_ecfp_public_key_t* pubKey)
 {
     for (int i = 0; i < 32; i++) {
-        outputBuffer[i] = publicKey->W[64 - i];
+        outputBuffer[i] = pubKey->W[64 - i];
     }
-    if ((publicKey->W[32] & 1) != 0) {
+    if ((pubKey->W[32] & 1) != 0) {
         outputBuffer[31] |= 0x80;
     }
 }
@@ -249,7 +249,7 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                 memset(privateKeyData, 0, 32);
 
                 unsigned char output[32];
-                extractPubKey(output, publicKey);
+                extractPubKey(output, &publicKey);
                 os_memmove(G_io_apdu_buffer, output, sizeof(output));
                 *tx += sizeof(output);
 
@@ -377,7 +377,7 @@ void handleApdu(volatile uint32_t* flags, volatile uint32_t* tx, uint32_t rx)
                     keys_ed25519(&publicKey, &privateKey, privateKeyDataTest);
 
                     unsigned char output[32];
-                    extractPubKey(output, publicKey);
+                    extractPubKey(output, &publicKey);
                     os_memmove(G_io_apdu_buffer, output, sizeof(output));
                     *tx += sizeof(output);
 

--- a/src/lib/JsonParser.c
+++ b/src/lib/JsonParser.c
@@ -388,7 +388,7 @@ int SignedMsgGetInfo(
 
         *view_scrolling_total_size = value_token.end-value_token.start;
 
-        char* value_start_address = message + value_token.start;
+        const char* value_start_address = message + value_token.start;
         if (view_scrolling_step < *view_scrolling_total_size) {
             int size =
                     *view_scrolling_total_size < max_chars_per_line ? *view_scrolling_total_size : max_chars_per_line;


### PR DESCRIPTION
Ledger keeps all the public keys in cx_ecfp_public_key_t structure, inside the 65 byte long buffer.
ed25519 public key has 32 bytes which are stored at the end in the reverse order (different endianess).

This fix was inspired by the Stellar app (https://github.com/lenondupe/ledger-app-stellar)
This change fixes Test_TestPublicKeyFromLedgerAndTendermint test which compares public key created by ledger with public key created by tendermint api (for the same private key bytes). 