### PR TITLE
Added support for writing long messages to nvram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ file(GLOB_RECURSE APP_SRC
         )
 
 file(GLOB_RECURSE LIB_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/json_parser.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/buffering.c
         )
 
 file(GLOB_RECURSE JSMN_SRC
@@ -55,19 +56,22 @@ target_link_libraries(json_parser jsmn)
 include(CTest)
 enable_testing()
 
-add_executable(tests_example
+add_executable(
+        tests_example
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/json_parser_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/buffering_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/transaction_parser_tests.cpp
-        )
+)
 
 target_link_libraries(tests_example gtest_main jsmn json_parser)
 add_test(gtest ${PROJECT_BINARY_DIR}/tests_example)
 
 ###############
 
-add_executable(main_example
+add_executable(
+        main_example
         ${LIB_SRC}
         ${APP_SRC}
-        )
+)
 
 target_link_libraries(main_example jsmn json_parser)

--- a/src/goclient/goclient.go
+++ b/src/goclient/goclient.go
@@ -87,6 +87,53 @@ func GetExampleTxs() []sdk.StdSignMsg {
 				},
 			},
 		}},
+		// Long message to test writing to nvram
+		sdk.StdSignMsg{"test-chain-1,test-chain-1,test-chain-1,test-chain-1,test-chain-1,test-chain-1", []int64{1}, sdk.NewStdFee(10000, sdk.Coin{"photonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphotonphoton", 5}), bank.MsgSend{
+			Inputs: []bank.Input{
+				{
+					Address: crypto.Address([]byte("input")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("input")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("input")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("input")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("input")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+			},
+			Outputs: []bank.Output{
+				{
+					Address: crypto.Address([]byte("output")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("output")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("output")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("output")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+				{
+					Address: crypto.Address([]byte("output")),
+					Coins:   sdk.Coins{{"atom", 10}},
+				},
+			},
+		}},
 		sdk.StdSignMsg{"test-chain-2", []int64{2}, sdk.NewStdFee(10000, sdk.Coin{"photon", 10}), stake.MsgUnbond{
 			DelegatorAddr: sdk.Address([]byte("delegator")),
 			CandidateAddr: sdk.Address([]byte("candidate")),
@@ -240,6 +287,6 @@ func main() {
 		ledger.Logging = true
 
 		testSECP256K1(GetExampleTxs(), ledger)
-		testED25519(GetExampleTxs(), ledger)
+		//testED25519(GetExampleTxs(), ledger)
 	}
 }

--- a/src/ledger/src/app_main.c
+++ b/src/ledger/src/app_main.c
@@ -161,6 +161,7 @@ bool process_chunk(volatile uint32_t* tx, uint32_t rx, bool getBip32)
     }
 
     if (packageIndex==1) {
+        transaction_initialize();
         transaction_reset();
         if (getBip32) {
             if (!extractBip32(&bip32_depth, bip32_path, rx, OFFSET_DATA)) {
@@ -171,6 +172,7 @@ bool process_chunk(volatile uint32_t* tx, uint32_t rx, bool getBip32)
     }
 
     transaction_append(&(G_io_apdu_buffer[offset]), rx-offset);
+
     return packageIndex==packageCount;
 }
 

--- a/src/ledger/src/transaction.h
+++ b/src/ledger/src/transaction.h
@@ -18,6 +18,8 @@
 #include "json_parser.h"
 #include "os.h"
 
+void transaction_initialize();
+
 // Clears the transaction buffer
 void transaction_reset();
 

--- a/src/lib/buffering.c
+++ b/src/lib/buffering.c
@@ -79,8 +79,9 @@ void buffering_append(uint8_t* data, int length)
         else {
             ram.in_use = 0;
             flash.in_use = 1;
-            append_flash_buffer(&flash, ram.data, ram.pos);
-            append_flash_buffer(&flash, data,length);
+            buffering_append(ram.data, ram.pos);
+            buffering_append(data,length);
+            ram.pos = 0;
         }
     }
     else {

--- a/src/lib/buffering.c
+++ b/src/lib/buffering.c
@@ -1,0 +1,100 @@
+/*******************************************************************************
+*   (c) 2016 Ledger
+*   (c) 2018 ZondaX GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#include "buffering.h"
+
+// Ram
+append_buffer_delegate append_ram_buffer = NULL;
+buffer_state_t ram;
+
+// Move to a separate file
+#define RAM_BUFFER_SIZE 512
+uint8_t ram_buffer[RAM_BUFFER_SIZE];
+
+// Flash
+append_buffer_delegate append_flash_buffer = NULL;
+buffer_state_t flash;
+
+// Move to a separate file
+#define FLASH_BUFFER_SIZE 16384
+typedef struct {
+    uint8_t buffer[FLASH_BUFFER_SIZE];
+} storage_t;
+extern storage_t N_appdata_impl;
+#define N_appdata (*(storage_t *)PIC(&N_appdata_impl))
+
+
+void buffering_init(
+        uint8_t* ram_buffer,
+        int ram_buffer_size,
+        append_buffer_delegate ram_delegate,
+        uint8_t* flash_buffer,
+        int flash_buffer_size,
+        append_buffer_delegate flash_delegate)
+{
+    append_ram_buffer = ram_delegate;
+    append_flash_buffer = flash_delegate;
+
+    ram.data = ram_buffer;
+    ram.size = ram_buffer_size;
+    ram.pos = 0;
+    ram.in_use = 1;
+    ram.initialized = 1;
+
+    flash.data = flash_buffer;
+    flash.size = flash_buffer_size;
+    flash.pos = 0;
+    flash.in_use = 0;
+    flash.initialized = 1;
+}
+
+void buffering_reset()
+{
+    ram.pos = 0;
+    ram.in_use = 1;
+    flash.pos = 0;
+    flash.in_use = 0;
+}
+
+void buffering_append(uint8_t* data, int length)
+{
+    if (ram.in_use) {
+        if (ram.size - ram.pos >= length) {
+            append_ram_buffer(&ram, data, length);
+        }
+        else {
+            ram.in_use = 0;
+            flash.in_use = 1;
+            append_flash_buffer(&flash, ram.data, ram.pos);
+            append_flash_buffer(&flash, data,length);
+        }
+    }
+    else {
+        append_flash_buffer(&flash, data, length);
+    }
+}
+
+
+buffer_state_t* buffering_get_ram_buffer()
+{
+    return &ram;
+}
+
+buffer_state_t* buffering_get_flash_buffer()
+{
+    return &flash;
+}

--- a/src/lib/buffering.c
+++ b/src/lib/buffering.c
@@ -21,22 +21,9 @@
 append_buffer_delegate append_ram_buffer = NULL;
 buffer_state_t ram;
 
-// Move to a separate file
-#define RAM_BUFFER_SIZE 512
-uint8_t ram_buffer[RAM_BUFFER_SIZE];
-
 // Flash
 append_buffer_delegate append_flash_buffer = NULL;
 buffer_state_t flash;
-
-// Move to a separate file
-#define FLASH_BUFFER_SIZE 16384
-typedef struct {
-    uint8_t buffer[FLASH_BUFFER_SIZE];
-} storage_t;
-extern storage_t N_appdata_impl;
-#define N_appdata (*(storage_t *)PIC(&N_appdata_impl))
-
 
 void buffering_init(
         uint8_t* ram_buffer,
@@ -75,17 +62,21 @@ void buffering_append(uint8_t* data, int length)
     if (ram.in_use) {
         if (ram.size - ram.pos >= length) {
             append_ram_buffer(&ram, data, length);
+            ram.pos += length;
         }
         else {
             ram.in_use = 0;
             flash.in_use = 1;
-            buffering_append(ram.data, ram.pos);
+            if (ram.pos > 0) {
+                buffering_append(ram.data, ram.pos);
+            }
             buffering_append(data,length);
             ram.pos = 0;
         }
     }
     else {
         append_flash_buffer(&flash, data, length);
+        flash.pos += length;
     }
 }
 
@@ -97,5 +88,13 @@ buffer_state_t* buffering_get_ram_buffer()
 
 buffer_state_t* buffering_get_flash_buffer()
 {
+    return &flash;
+}
+
+buffer_state_t* buffering_get_buffer()
+{
+    if (ram.in_use) {
+        return &ram;
+    }
     return &flash;
 }

--- a/src/lib/buffering.h
+++ b/src/lib/buffering.h
@@ -49,6 +49,7 @@ void buffering_append(uint8_t* data, int length);
 
 buffer_state_t* buffering_get_ram_buffer();
 buffer_state_t* buffering_get_flash_buffer();
+buffer_state_t* buffering_get_buffer();
 
 
 #ifdef __cplusplus

--- a/src/lib/buffering.h
+++ b/src/lib/buffering.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+*   (c) 2016 Ledger
+*   (c) 2018 ZondaX GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#ifndef CI_TEST_BUFFERING_H
+#define CI_TEST_BUFFERING_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t* data;
+    uint16_t size;
+    uint16_t pos;
+    uint8_t in_use: 1;
+    uint8_t initialized : 1;
+} buffer_state_t;
+
+typedef void (*append_buffer_delegate)(buffer_state_t* buffer, uint8_t* data, int size);
+
+void buffering_init(
+        uint8_t* ram_buffer,
+        int ram_buffer_size,
+        append_buffer_delegate ram,
+        uint8_t* flash_buffer,
+        int flash_buffer_size,
+        append_buffer_delegate flash);
+
+void buffering_reset();
+
+void buffering_append(uint8_t* data, int length);
+
+buffer_state_t* buffering_get_ram_buffer();
+buffer_state_t* buffering_get_flash_buffer();
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CI_TEST_BUFFERING_H

--- a/tests/buffering_tests.cpp
+++ b/tests/buffering_tests.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+*   (c) 2016 Ledger
+*   (c) 2018 ZondaX GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#include "gtest/gtest.h"
+#include "lib/buffering.h"
+
+namespace {
+
+    TEST(Buffering, SmallBuffer) {
+
+        uint8_t ram_buffer[100];
+        uint8_t flash_buffer[1000];
+
+        buffering_init(
+                ram_buffer,
+                sizeof(ram_buffer),
+                [](buffer_state_t* buffer, uint8_t* data, int size) {
+                    memcpy(buffer->data+buffer->pos, data, size);
+                    buffer->pos += size;
+                },
+                flash_buffer,
+                sizeof(flash_buffer),
+                [](buffer_state_t* buffer, uint8_t* data, int size) {
+                    memcpy(buffer->data+buffer->pos, data, size);
+                    buffer->pos += size;
+                });
+
+        uint8_t small[100];
+        buffering_append(small, sizeof(small));
+        EXPECT_TRUE(buffering_get_ram_buffer()->in_use) << "Writing small buffer should only write to RAM";
+        EXPECT_FALSE(buffering_get_flash_buffer()->in_use) << "Writing big buffer should write data to FLASH";
+    }
+
+    TEST(Buffering, BigBuffer) {
+
+        uint8_t ram_buffer[100];
+        uint8_t flash_buffer[1000];
+
+        buffering_init(
+                ram_buffer,
+                sizeof(ram_buffer),
+                [](buffer_state_t* buffer, uint8_t* data, int size) {
+                    memcpy(buffer->data+buffer->pos, data, size);
+                    buffer->pos += size;
+                },
+                flash_buffer,
+                sizeof(flash_buffer),
+                [](buffer_state_t* buffer, uint8_t* data, int size) {
+                    memcpy(buffer->data+buffer->pos, data, size);
+                    buffer->pos += size;
+                });
+
+        uint8_t big[1000];
+        buffering_append(big, sizeof(big));
+        EXPECT_FALSE(buffering_get_ram_buffer()->in_use) << "Writing big buffer should write data to FLASH";
+        EXPECT_TRUE(buffering_get_flash_buffer()->in_use) << "Writing big buffer should write data to FLASH";
+    }
+}

--- a/tests/buffering_tests.cpp
+++ b/tests/buffering_tests.cpp
@@ -98,8 +98,7 @@ namespace {
         EXPECT_TRUE(buffering_get_ram_buffer()->in_use) << "Writing small buffer should only write to RAM";
         EXPECT_FALSE(buffering_get_flash_buffer()->in_use) << "Writing big buffer should write data to FLASH";
 
-        // And again, this time ram is not big enough to hold the data
-        // and data will be copied to flash
+        // Here we write another chunk which should not top over the ram buffer
         buffering_append(small, sizeof(small));
         EXPECT_TRUE(buffering_get_ram_buffer()->in_use) << "Writing small buffer should only write to RAM";
         EXPECT_FALSE(buffering_get_flash_buffer()->in_use) << "Writing big buffer should write data to FLASH";
@@ -132,8 +131,8 @@ namespace {
         EXPECT_TRUE(buffering_get_ram_buffer()->in_use) << "Writing small buffer should only write to RAM";
         EXPECT_FALSE(buffering_get_flash_buffer()->in_use) << "Writing big buffer should write data to FLASH";
 
-        // And again, this time ram is not big enough to hold the data
-        // and data will be copied to flash
+        // Here we append another small buffer, this time we're going to exceed ram's size
+        // data will be copied to nvram
         buffering_append(small, sizeof(small));
         EXPECT_FALSE(buffering_get_ram_buffer()->in_use) << "Data should be now in FLASH";
         EXPECT_TRUE(buffering_get_flash_buffer()->in_use) << "Data should be now in FLASH";
@@ -172,6 +171,7 @@ namespace {
             small2[i] = 100 - i;
         }        buffering_append(small2, sizeof(small2));
 
+        // In this test we want to make sure that data is not compromised.
         uint8_t* dst = buffering_get_flash_buffer()->data;
         for (int i=0;i<sizeof(small1)+sizeof(small2);i++) {
             if (i < sizeof(small1)) {


### PR DESCRIPTION
In PR we enable support for long messages, up to 16KB, by using nvram.

Introduced new buffering.c file that contains logic for writing to a default, small buffer (512 bytes) in ram and switching to nvram if data is bigger.

Added bunch of unit tests to validate buffering behavior plus integration test in goclient to test long messages directly in the ledger.  