### PR TITLE
Json validation, part 1

### DIFF
--- a/src/lib/json_parser.c
+++ b/src/lib/json_parser.c
@@ -27,7 +27,7 @@ void json_parse(parsed_json_t *parsed_json, const char *transaction) {
         parsed_json->Tokens,
         MAX_NUMBER_OF_TOKENS);
 
-    parsed_json->CorrectFormat = false;
+    parsed_json->IsValid = false;
 
     if (num_tokens > 255) {
         return;
@@ -36,16 +36,8 @@ void json_parse(parsed_json_t *parsed_json, const char *transaction) {
     parsed_json->NumberOfTokens = (byte) num_tokens;
     if (parsed_json->NumberOfTokens >= 1 &&
         parsed_json->Tokens[0].type != JSMN_OBJECT) {
-        parsed_json->CorrectFormat = true;
+        parsed_json->IsValid = true;
     }
-}
-
-int json_validate(const char *transaction,
-                  char *errorMsg,
-                  int errMsgLength) {
-    strcpy(errorMsg, "Not implemented.");
-    // Here we make sure that json have correct format according to the spec
-    return -1;
 }
 
 int array_get_element_count(int array_token_index,

--- a/src/lib/json_parser.c
+++ b/src/lib/json_parser.c
@@ -27,15 +27,19 @@ void json_parse(parsed_json_t *parsed_json, const char *transaction) {
         parsed_json->Tokens,
         MAX_NUMBER_OF_TOKENS);
 
-    parsed_json->IsValid = false;
-
     if (num_tokens > 255) {
+        parsed_json->IsValid = false;
         return;
     }
 
     parsed_json->NumberOfTokens = (byte) num_tokens;
-    if (parsed_json->NumberOfTokens >= 1 &&
-        parsed_json->Tokens[0].type != JSMN_OBJECT) {
+    if (parsed_json->NumberOfTokens < 1) {
+        parsed_json->IsValid = false;
+    }
+//    else if (parsed_json->Tokens[0].type != JSMN_OBJECT) {
+//        parsed_json->IsValid = false;
+//    }
+     else {
         parsed_json->IsValid = true;
     }
 }

--- a/src/lib/json_parser.h
+++ b/src/lib/json_parser.h
@@ -36,8 +36,7 @@ typedef unsigned char byte;
 //  - parsed json tokens
 //  - re-created SendMsg struct with indices pointing to tokens in parsed json
 typedef struct {
-    // Tokens
-    bool CorrectFormat;
+    bool IsValid;
     byte NumberOfTokens;
     jsmntok_t Tokens[MAX_NUMBER_OF_TOKENS];
 } parsed_json_t;
@@ -58,14 +57,14 @@ typedef struct {
 void json_parse(parsed_json_t *parsed_json,
                 const char *transaction);
 
-/// Get number of elements in array
+/// Get the number of elements in the array
 /// \param array_token_index
 /// \param parsed_transaction
 /// \return
 int array_get_element_count(int array_token_index,
                             const parsed_json_t *parsed_transaction);
 
-/// Get token index of the nth array's element
+/// Get the token index of the nth array's element
 /// \param array_token_index
 /// \param element_index
 /// \param parsed_transaction
@@ -74,15 +73,15 @@ int array_get_nth_element(int array_token_index,
                           int element_index,
                           const parsed_json_t *parsed_transaction);
 
-/// Get number of elements (key/value pairs) in object
-/// \param object_token_index
+/// Get the number of dictionary elements (key/value pairs) under given object
+/// \param object_token_index: token index of the parent object
 /// \param parsed_transaction
 /// \return
 int object_get_element_count(int object_token_index,
                              const parsed_json_t *parsed_transaction);
 
-/// Get token index for the nth key
-/// \param object_token_index
+/// Get the token index for the nth dictionary key
+/// \param object_token_index: token index of the parent object
 /// \param object_element_index
 /// \param parsed_transaction
 /// \return
@@ -90,8 +89,8 @@ int object_get_nth_key(int object_token_index,
                        int object_element_index,
                        const parsed_json_t *parsed_transaction);
 
-/// Get token index for the nth value
-/// \param object_token_index
+/// Get the token index for the nth dictionary value
+/// \param object_token_index: token index of the parent object
 /// \param object_element_index
 /// \param parsed_transaction
 /// \return
@@ -99,9 +98,9 @@ int object_get_nth_value(int object_token_index,
                          int object_element_index,
                          const parsed_json_t *parsed_transaction);
 
-/// Get token index for the value that matched given key
-/// \param object_token_index
-/// \param key_name
+/// Get the token index of the value that matches the given key
+/// \param object_token_index: token index of the parent object
+/// \param key_name: key name of the wanted value
 /// \param parsed_transaction
 /// \param transaction
 /// \return

--- a/src/lib/transaction_parser.h
+++ b/src/lib/transaction_parser.h
@@ -89,6 +89,14 @@ int transaction_get_display_key_value(char *key,
 /// \return
 int transaction_get_display_pages();
 
+/// Validate json transaction
+/// \param parsed_transacton
+/// \param transaction
+/// \return
+const char* json_validate(
+        parsed_json_t* parsed_transaction,
+        const char *transaction);
+
 //---------------------------------------------
 // Delegates
 

--- a/tests/json_parser_tests.cpp
+++ b/tests/json_parser_tests.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <array>
 #include <jsmn.h>
+#include <lib/json_parser.h>
 
 namespace {
 std::string exec(const char *cmd) {
@@ -42,7 +43,7 @@ TEST(JsonParserTest, Empty) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, "");
 
-    EXPECT_FALSE(parserData.CorrectFormat);
+    EXPECT_FALSE(parserData.IsValid);
     EXPECT_EQ(0, parserData.NumberOfTokens);
 }
 
@@ -50,7 +51,7 @@ TEST(JsonParserTest, SinglePrimitive) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, "EMPTY");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(1, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_PRIMITIVE);
 }
@@ -59,7 +60,7 @@ TEST(JsonParserTest, KeyValuePrimitives) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, "KEY : VALUE");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(2, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_PRIMITIVE);
     EXPECT_TRUE(parserData.Tokens[1].type == jsmntype_t::JSMN_PRIMITIVE);
@@ -69,7 +70,7 @@ TEST(JsonParserTest, SingleString) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, "\"EMPTY\"");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(1, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_STRING);
 }
@@ -78,7 +79,7 @@ TEST(JsonParserTest, KeyValueStrings) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, R"("KEY" : "VALUE")");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(2, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_STRING);
     EXPECT_TRUE(parserData.Tokens[1].type == jsmntype_t::JSMN_STRING);
@@ -88,7 +89,7 @@ TEST(JsonParserTest, SimpleArray) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, "LIST : [1, 2, 3, 4]");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(6, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_PRIMITIVE);
     EXPECT_TRUE(parserData.Tokens[1].type == jsmntype_t::JSMN_ARRAY);
@@ -102,7 +103,7 @@ TEST(JsonParserTest, MixedArray) {
     parsed_json_t parserData = {false};
     json_parse(&parserData, R"(LIST : [1, "Text", 3, "Another text"])");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(6, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_PRIMITIVE);
     EXPECT_TRUE(parserData.Tokens[1].type == jsmntype_t::JSMN_ARRAY);
@@ -122,7 +123,7 @@ TEST(JsonParserTest, SimpleObject) {
                             "\"total\":123 }"
                             "}");
 
-    EXPECT_TRUE(parserData.CorrectFormat);
+    EXPECT_TRUE(parserData.IsValid);
     EXPECT_EQ(10, parserData.NumberOfTokens);
     EXPECT_TRUE(parserData.Tokens[0].type == jsmntype_t::JSMN_PRIMITIVE);
     EXPECT_TRUE(parserData.Tokens[1].type == jsmntype_t::JSMN_OBJECT);

--- a/tests/transaction_parser_tests.cpp
+++ b/tests/transaction_parser_tests.cpp
@@ -834,7 +834,6 @@ TEST(TransactionParserTest, TransactionJsonValidation_Spaces_InTheMiddle) {
 
     parsed_json_t parsed_transaction;
     json_parse(&parsed_transaction, transaction);
-    EXPECT_FALSE(parsed_transaction.IsValid) << "Json with spaces should fail validation";
 
     const char* error_msg = json_validate(&parsed_transaction, transaction);
     EXPECT_EQ_STR(error_msg, "Contains whitespace in the corpus", "Validation should fail because contains whitespace in the corpus");
@@ -845,7 +844,6 @@ TEST(TransactionParserTest, TransactionJsonValidation_Spaces_AtTheFront) {
 
     parsed_json_t parsed_transaction;
     json_parse(&parsed_transaction, transaction);
-    EXPECT_FALSE(parsed_transaction.IsValid) << "Json with spaces should fail validation";
 
     const char* error_msg = json_validate(&parsed_transaction, transaction);
     EXPECT_EQ_STR(error_msg, "Contains whitespace in the corpus", "Validation should fail because contains whitespace in the corpus");
@@ -856,7 +854,6 @@ TEST(TransactionParserTest, TransactionJsonValidation_Spaces_AtTheEnd) {
 
     parsed_json_t parsed_transaction;
     json_parse(&parsed_transaction, transaction);
-    EXPECT_FALSE(parsed_transaction.IsValid) << "Json with spaces should fail validation";
 
     const char* error_msg = json_validate(&parsed_transaction, transaction);
     EXPECT_EQ_STR(error_msg, "Contains whitespace in the corpus", "Validation should fail because contains whitespace in the corpus");
@@ -867,9 +864,19 @@ TEST(TransactionParserTest, TransactionJsonValidation_Spaces_Lots) {
 
     parsed_json_t parsed_transaction;
     json_parse(&parsed_transaction, transaction);
-    EXPECT_FALSE(parsed_transaction.IsValid) << "Json with spaces should fail validation";
 
     const char* error_msg = json_validate(&parsed_transaction, transaction);
     EXPECT_EQ_STR(error_msg, "Contains whitespace in the corpus", "Validation should fail because contains whitespace in the corpus");
+}
+
+TEST(TransactionParserTest, TransactionJsonValidation_AllowSpacesInString) {
+
+    auto transaction = R"({"alt_bytes\t":null,"chain_id\r":"test-chain-1\n","fee_bytes":{"amount":[{"amount":5,"denom":"photon"}],"gas":10000},"msg_bytes":{"inputs":[{"address":"696E707574","coins":[{"amount":10,"denom":"atom"}]}],"outputs":[{"address":"6F7574707574","coins":[{"amount\n\n\n\n\n":10,"denom":"atom"}]}]},"sequence\t\t\t\t":1})";
+
+    parsed_json_t parsed_transaction;
+    json_parse(&parsed_transaction, transaction);
+
+    const char* error_msg = json_validate(&parsed_transaction, transaction);
+    EXPECT_TRUE(error_msg == NULL) << "Validation failed, error: " << error_msg;
 }
 }


### PR DESCRIPTION
Added json validation and unit tests. Types of validation:
- any whitespace in the corpus of the transaction will fail validation (escaped whitespaces in  strings are allowed)
- any transaction message that does not contain predefined elements i.e. sequence, msg_bytes, fee_bytes, alt_bytes will fail the validation. 